### PR TITLE
fix: use stable release version of pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<=3.13"
+pydantic = "2.7.4"  # Prevent the buggy 2.8.0b1 prerelease
 
 datasets = "2.19.0"
 


### PR DESCRIPTION
Ran into the error:

```
TypeError: _eval_type() got an unexpected keyword argument 'type_params'
```

The error did not seem to have anything to do with Moatless Tools at all but some internal issue with Pydantic 2.8.0b1, which is a pre-release. Downgrading to the latest stable release seems to fix the issue.