### PR TITLE
fix: correct disable_thoughts logic in system prompt

### DIFF
--- a/moatless/completion/react.py
+++ b/moatless/completion/react.py
@@ -41,7 +41,7 @@ class ReActCompletionModel(BaseCompletionModel):
         system_prompt += dedent(f"""\n# Response format
 
 Use the following format:
-{'' if not self.disable_thoughts else '''
+{'' if self.disable_thoughts else '''
 Thought: You should always think about what to do'''}
 Action: The action to take followed by the input arguments based on the schema below
 
@@ -49,7 +49,7 @@ Use one of the following actions and provide input arguments matching the schema
                             
 {input_schemas}
 
-Important: Do not include multiple{' Thought-' if self.disable_thoughts else ''} Action blocks. Do not include code blocks or additional text outside of this format.
+Important: Do not include multiple{'' if self.disable_thoughts else ' Thought-'} Action blocks. Do not include code blocks or additional text outside of this format.
 """)
         return system_prompt
 


### PR DESCRIPTION
I found that the logic in `moatless-tools/moatless/completion/react.py:44 - 52` is conflicting with the check logic in `moatless-tools/moatless/completion/react.py:146 - 151`

```python
# moatless-tools/moatless/completion/react.py:44 - 52
system_prompt += dedent(f"""\n# Response format

Use the following format:
{'' if not self.disable_thoughts else '''            # Meaning that use prompt with 'thought' when `disable_thoughts` is `True` 
Thought: You should always think about what to do'''}
Action: The action to take followed by the input arguments based on the schema below

Use one of the following actions and provide input arguments matching the schema.
                            
{input_schemas}

Important: Do not include multiple{'' if self.disable_thoughts else ' Thought-'} Action blocks. Do not include code blocks or additional text outside of this format.
""")

```



```python
# moatless-tools/moatless/completion/react.py:146 - 151

if not self.disable_thoughts and thought_count < 1:   # Meaning that there needs a 'Thought' when `disable_thoughts` is `True`
    raise ValueError("The response is incorrect, it should start with 'Thought:'")
if action_count < 1:
    raise ValueError("Response must have one 'Action:' section")

if not self.disable_thoughts:
    # Find the starting lines for each section
    thought_line = next((i for i, line in enumerate(lines) if line.startswith("Thought:")), -1)
    action_line = next((i for i, line in enumerate(lines) if line.startswith("Action:")), -1)

    # Check if sections are in correct order
    if not (thought_line < action_line):
        raise ValueError(
            "Your response is incorrect. The Thought section must come before the Action section. Please try the same request again with the correct format."
        )
```


After comparing, I think the logic in 146-151 might be the right one, so I took the liberty to modify the above logic, I don't know if the modification is correct.